### PR TITLE
Basic keylistener for new window

### DIFF
--- a/src/bt2d/core/container/GameContainer.java
+++ b/src/bt2d/core/container/GameContainer.java
@@ -4,6 +4,8 @@ import bt.types.Killable;
 import bt2d.core.container.exc.GameContainerException;
 import bt2d.core.container.settings.GameContainerSettings;
 import bt2d.core.container.settings.exc.SettingsChangeException;
+import bt2d.core.input.key.KeyActions;
+import bt2d.core.input.key.KeyInput;
 import bt2d.core.loop.GameLoop;
 import bt2d.core.window.Window;
 import bt2d.utils.Unit;
@@ -51,6 +53,11 @@ public class GameContainer implements Runnable, Killable
     protected Unit height;
 
     /**
+     * A set of key actions that can be freely configured to setup global triggers.
+     */
+    protected KeyActions keyActions;
+
+    /**
      * Instantiates a new Game container.
      *
      * @param settings the settings that will be bound by this container. Changes to the properties
@@ -62,6 +69,7 @@ public class GameContainer implements Runnable, Killable
     public GameContainer(GameContainerSettings settings)
     {
         this.settings = settings;
+        this.keyActions = new KeyActions();
     }
 
     /**
@@ -158,6 +166,8 @@ public class GameContainer implements Runnable, Killable
         this.width = Unit.forPixels(this.window.getWidth());
         this.height = Unit.forPixels(this.window.getHeight());
 
+        new KeyInput(this.window.getWindow());
+
         this.window.showWindow();
 
         GL.createCapabilities();
@@ -186,6 +196,10 @@ public class GameContainer implements Runnable, Killable
         // TODO forward tick call to scene
 
         glfwPollEvents();
+
+        KeyInput.get().checkKeyChanges();
+
+        this.keyActions.checkActions();
 
         if (this.window.isShouldClose())
         {
@@ -311,5 +325,10 @@ public class GameContainer implements Runnable, Killable
     public Unit getHeight()
     {
         return height;
+    }
+
+    public KeyActions getKeyActions()
+    {
+        return this.keyActions;
     }
 }

--- a/src/bt2d/core/container/GameContainer.java
+++ b/src/bt2d/core/container/GameContainer.java
@@ -58,6 +58,11 @@ public class GameContainer implements Runnable, Killable
     protected KeyActions keyActions;
 
     /**
+     * This containers key input instacne which is used to check pressed keys.
+     */
+    protected KeyInput keyInput;
+
+    /**
      * Instantiates a new Game container.
      *
      * @param settings the settings that will be bound by this container. Changes to the properties
@@ -166,8 +171,6 @@ public class GameContainer implements Runnable, Killable
         this.width = Unit.forPixels(this.window.getWidth());
         this.height = Unit.forPixels(this.window.getHeight());
 
-        new KeyInput(this.window.getWindow());
-
         this.window.showWindow();
 
         GL.createCapabilities();
@@ -179,6 +182,19 @@ public class GameContainer implements Runnable, Killable
                 0.f,
                 0.f,
                 1.f);
+    }
+
+    /**
+     * Creates the {@link KeyInput} instance of this container.
+     * <p>
+     * The setup instance will be available via {@link #getKeyInput()}.
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    protected void setupKeyInput()
+    {
+        this.keyInput = new KeyInput(this.window.getWindow());
     }
 
     /**
@@ -197,9 +213,8 @@ public class GameContainer implements Runnable, Killable
 
         glfwPollEvents();
 
-        KeyInput.get().checkKeyChanges();
-
-        this.keyActions.checkActions();
+        this.keyInput.checkKeyChanges();
+        this.keyActions.checkActions(this.keyInput);
 
         if (this.window.isShouldClose())
         {
@@ -268,6 +283,7 @@ public class GameContainer implements Runnable, Killable
     {
         createWindow();
         bindSettings();
+        setupKeyInput();
 
         if (this.loop == null)
         {
@@ -327,8 +343,33 @@ public class GameContainer implements Runnable, Killable
         return height;
     }
 
+    /**
+     * Returns a set of key actions that can be extended.
+     * <p>
+     * This can be used to add global key actions to this container.
+     *
+     * @return The key actions which were setup for this container.
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
     public KeyActions getKeyActions()
     {
         return this.keyActions;
+    }
+
+    /**
+     * Gets {@link KeyInput} instance that was setup for this container.
+     * <p>
+     * The returned instance can be used to check if certain keys were pressed.
+     *
+     * @return The key input instance setup for this container.
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public KeyInput getKeyInput()
+    {
+        return this.keyInput;
     }
 }

--- a/src/bt2d/core/input/key/Key.java
+++ b/src/bt2d/core/input/key/Key.java
@@ -1,0 +1,181 @@
+package bt2d.core.input.key;
+
+import java.util.Objects;
+
+/**
+ * A simple entity describing a key + mods combination.
+ *
+ * @author Lukas Hartwig
+ * @since 03.11.2021
+ */
+public class Key
+{
+    /**
+     * Status for a key that is currently not pressed.
+     */
+    public static final int KEY_NOT_DOWN = 0;
+
+    /**
+     * Status for a key that is currently pressed.
+     */
+    public static final int KEY_DOWN = 1;
+
+    /**
+     * Status for a key that was just pressed during the last tick.
+     */
+    public static final int KEY_JUST_DOWN = 2;
+
+    /**
+     * Status for a key that was just released during the last tick.
+     */
+    public static final int KEY_RELEASED = 3;
+
+    /**
+     * The keycode of this key.
+     */
+    private int keycode;
+
+    /**
+     * The status of this key, i.e. {@link KeyInput#KEY_DOWN}.
+     */
+    private int status;
+
+    /**
+     * Bitmask for mods that are pressed with this key, i.e. shift or alt.
+     */
+    private int mods;
+
+    /**
+     * Instantiates a new Key.
+     *
+     * @param keycode the keycode
+     * @param status  the status
+     * @param mods    the mods
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public Key(int keycode, int status, int mods)
+    {
+        this.keycode = keycode;
+        this.status = status;
+        this.mods = mods;
+    }
+
+    /**
+     * Gets keycode.
+     *
+     * @return the keycode
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public int getKeycode()
+    {
+        return keycode;
+    }
+
+    /**
+     * Sets keycode.
+     *
+     * @param keycode the keycode
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public void setKeycode(int keycode)
+    {
+        this.keycode = keycode;
+    }
+
+    /**
+     * Gets status.
+     *
+     * @return the status
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public int getStatus()
+    {
+        return status;
+    }
+
+    /**
+     * Sets status.
+     *
+     * @param status the status
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public void setStatus(int status)
+    {
+        this.status = status;
+    }
+
+    /**
+     * Gets mods.
+     *
+     * @return the mods
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public int getMods()
+    {
+        return mods;
+    }
+
+    /**
+     * Sets mods.
+     *
+     * @param mods the mods
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public void setMods(int mods)
+    {
+        this.mods = mods;
+    }
+
+    /**
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Key key = (Key)o;
+        return keycode == key.keycode && status == key.status && mods == key.mods;
+    }
+
+    /**
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(keycode, status, mods);
+    }
+
+    /**
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    @Override
+    public String toString()
+    {
+        return "Key{" +
+                "keycode=" + keycode +
+                ", status=" + status +
+                ", mods=" + mods +
+                '}';
+    }
+}

--- a/src/bt2d/core/input/key/KeyActions.java
+++ b/src/bt2d/core/input/key/KeyActions.java
@@ -4,13 +4,16 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * The type Key actions.
+ * Defines a set of actions mapped to specific keys.
  *
  * @author Lukas Hartwig
  * @since 03.11.2021
  */
 public class KeyActions
 {
+    /**
+     * The actions mapped by the key + mods combination.
+     */
     private Map<Key, Runnable> actions;
 
     /**
@@ -25,10 +28,14 @@ public class KeyActions
     }
 
     /**
-     * On key down.
+     * Defines an action that is executed if the given key is pressed.
+     * <p>
+     * If the key remains pressed then this action will be executed every tick.
+     * <p>
+     * For one time actions see {@link #onKeyJustDown(int, Runnable)}.
      *
-     * @param key    the key
-     * @param action the action
+     * @param key    the key code of the trigger key.
+     * @param action the action to execute.
      *
      * @author Lukas Hartwig
      * @since 03.11.2021
@@ -39,11 +46,15 @@ public class KeyActions
     }
 
     /**
-     * On key down.
+     * Defines an action that is executed if the given key + mods combination is pressed.
+     * <p>
+     * If the key remains pressed then this action will be executed every tick.
+     * <p>
+     * For one time actions see {@link #onKeyJustDown(int, int, Runnable)}.
      *
-     * @param key    the key
-     * @param mods   the mods
-     * @param action the action
+     * @param key    the key code of the trigger key.
+     * @param mods   the mods of this key press, i.e. shift or alt.
+     * @param action the action to execute.
      *
      * @author Lukas Hartwig
      * @since 03.11.2021
@@ -54,10 +65,12 @@ public class KeyActions
     }
 
     /**
-     * On key just down.
+     * Defines an action that is executed if the given key is pressed.
+     * <p>
+     * This is a one time per key press action. If the key remains pressed this action will not be repeated.
      *
-     * @param key    the key
-     * @param action the action
+     * @param key    the key code of the trigger key.
+     * @param action the action to execute.
      *
      * @author Lukas Hartwig
      * @since 03.11.2021
@@ -68,11 +81,13 @@ public class KeyActions
     }
 
     /**
-     * On key just down.
+     * Defines an action that is executed if the given key + mods combination is pressed.
+     * <p>
+     * This is a one time per key press action. If the key remains pressed this action will not be repeated.
      *
-     * @param key    the key
-     * @param mods   the mods
-     * @param action the action
+     * @param key    the key code of the trigger key.
+     * @param mods   the mods of this key press, i.e. shift or alt.
+     * @param action the action to execute.
      *
      * @author Lukas Hartwig
      * @since 03.11.2021
@@ -83,10 +98,12 @@ public class KeyActions
     }
 
     /**
-     * On keyreleased.
+     * Defines an action that is executed if the given key is released.
+     * <p>
+     * This is a one time per release action which will be executed in the same tick as the releasing is detected.
      *
-     * @param key    the key
-     * @param action the action
+     * @param key    the key code of the trigger key.
+     * @param action the action to execute.
      *
      * @author Lukas Hartwig
      * @since 03.11.2021
@@ -97,11 +114,13 @@ public class KeyActions
     }
 
     /**
-     * On keyreleased.
+     * Defines an action that is executed if the given key + mods combination is released.
+     * <p>
+     * This is a one time per release action which will be executed in the same tick as the releasing is detected.
      *
-     * @param key    the key
-     * @param mods   the mods
-     * @param action the action
+     * @param key    the key code of the trigger key.
+     * @param mods   the mods of this key press, i.e. shift or alt.
+     * @param action the action to execute.
      *
      * @author Lukas Hartwig
      * @since 03.11.2021
@@ -112,24 +131,27 @@ public class KeyActions
     }
 
     /**
-     * Check actions.
+     * Check if any of the configured actions need to be executed based on the given KeyInput instance.
+     * <p>
+     * This method should be called during every tick iteration after the
+     * KeyInputs {@link KeyInput#checkKeyChanges()} method was called.
      *
      * @author Lukas Hartwig
      * @since 03.11.2021
      */
-    public void checkActions()
+    public void checkActions(KeyInput input)
     {
         for (Key key : this.actions.keySet())
         {
-            if (key.getStatus() == Key.KEY_DOWN && KeyInput.get().isKeyDown(key.getKeycode(), key.getMods()))
+            if (key.getStatus() == Key.KEY_DOWN && input.isKeyDown(key.getKeycode(), key.getMods()))
             {
                 this.actions.get(key).run();
             }
-            else if (key.getStatus() == Key.KEY_JUST_DOWN && KeyInput.get().isKeyJustDown(key.getKeycode(), key.getMods()))
+            else if (key.getStatus() == Key.KEY_JUST_DOWN && input.isKeyJustDown(key.getKeycode(), key.getMods()))
             {
                 this.actions.get(key).run();
             }
-            else if (key.getStatus() == Key.KEY_RELEASED && KeyInput.get().isKeyReleased(key.getKeycode(), key.getMods()))
+            else if (key.getStatus() == Key.KEY_RELEASED && input.isKeyReleased(key.getKeycode(), key.getMods()))
             {
                 this.actions.get(key).run();
             }

--- a/src/bt2d/core/input/key/KeyActions.java
+++ b/src/bt2d/core/input/key/KeyActions.java
@@ -1,0 +1,138 @@
+package bt2d.core.input.key;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The type Key actions.
+ *
+ * @author Lukas Hartwig
+ * @since 03.11.2021
+ */
+public class KeyActions
+{
+    private Map<Key, Runnable> actions;
+
+    /**
+     * Instantiates a new Key actions.
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public KeyActions()
+    {
+        this.actions = new HashMap<>();
+    }
+
+    /**
+     * On key down.
+     *
+     * @param key    the key
+     * @param action the action
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public void onKeyDown(int key, Runnable action)
+    {
+        onKeyDown(key, 0, action);
+    }
+
+    /**
+     * On key down.
+     *
+     * @param key    the key
+     * @param mods   the mods
+     * @param action the action
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public void onKeyDown(int key, int mods, Runnable action)
+    {
+        this.actions.put(new Key(key, Key.KEY_DOWN, mods), action);
+    }
+
+    /**
+     * On key just down.
+     *
+     * @param key    the key
+     * @param action the action
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public void onKeyJustDown(int key, Runnable action)
+    {
+        onKeyJustDown(key, 0, action);
+    }
+
+    /**
+     * On key just down.
+     *
+     * @param key    the key
+     * @param mods   the mods
+     * @param action the action
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public void onKeyJustDown(int key, int mods, Runnable action)
+    {
+        this.actions.put(new Key(key, Key.KEY_JUST_DOWN, mods), action);
+    }
+
+    /**
+     * On keyreleased.
+     *
+     * @param key    the key
+     * @param action the action
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public void onKeyreleased(int key, Runnable action)
+    {
+        onKeyreleased(key, 0, action);
+    }
+
+    /**
+     * On keyreleased.
+     *
+     * @param key    the key
+     * @param mods   the mods
+     * @param action the action
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public void onKeyreleased(int key, int mods, Runnable action)
+    {
+        this.actions.put(new Key(key, Key.KEY_RELEASED, mods), action);
+    }
+
+    /**
+     * Check actions.
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public void checkActions()
+    {
+        for (Key key : this.actions.keySet())
+        {
+            if (key.getStatus() == Key.KEY_DOWN && KeyInput.get().isKeyDown(key.getKeycode(), key.getMods()))
+            {
+                this.actions.get(key).run();
+            }
+            else if (key.getStatus() == Key.KEY_JUST_DOWN && KeyInput.get().isKeyJustDown(key.getKeycode(), key.getMods()))
+            {
+                this.actions.get(key).run();
+            }
+            else if (key.getStatus() == Key.KEY_RELEASED && KeyInput.get().isKeyReleased(key.getKeycode(), key.getMods()))
+            {
+                this.actions.get(key).run();
+            }
+        }
+    }
+}

--- a/src/bt2d/core/input/key/KeyInput.java
+++ b/src/bt2d/core/input/key/KeyInput.java
@@ -1,0 +1,268 @@
+package bt2d.core.input.key;
+
+import org.lwjgl.glfw.GLFW;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A central place that will listen for key callbacks from an GLFW window.
+ * <p>
+ * This class offers methods to check if a key is currently pressed or or released.
+ *
+ * @author Lukas Hartwig
+ * @since 02.11.2021
+ */
+public class KeyInput
+{
+    /**
+     * The singleton instance.
+     */
+    private volatile static KeyInput instance;
+
+    /**
+     * The keys mapped by their keycode keeping track of their status.
+     */
+    private Map<Integer, Key> keyValues;
+
+    /**
+     * Staged changes to the main keyValues map, will be merged during the next call of {@link #checkKeyChanges()}.
+     */
+    private Map<Integer, Key> keyChanges;
+
+    /**
+     * Instantiates a new Key input.
+     *
+     * @param windowRef the window ref
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public KeyInput(long windowRef)
+    {
+        instance = this;
+        this.keyValues = new HashMap<>();
+        this.keyChanges = new HashMap<>();
+        GLFW.glfwSetKeyCallback(windowRef, this::onKeyAction);
+    }
+
+    /**
+     * Get key input.
+     *
+     * @return the key input
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public static KeyInput get()
+    {
+        return instance;
+    }
+
+    /**
+     * Indicates whether a key is just now being pressed. This state does not last longer than one tick.
+     *
+     * @param key The key code (constant from {@link GLFW}) of the key to check.
+     *
+     * @return true if the key was just pressed.
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public boolean isKeyJustDown(int key)
+    {
+        return isKeyJustDown(key, 0);
+    }
+
+    /**
+     * Indicates whether a key + mods combination is just now being pressed. This state does not last longer than one tick.
+     *
+     * @param key  The key code (constant from {@link GLFW}) of the key to check.
+     * @param mods Bitmask of the mods that are pressed with the key, i.e shift and alt.
+     *
+     * @return true if the key + mods combination was just pressed.
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public boolean isKeyJustDown(int key, int mods)
+    {
+        var entry = this.keyValues.get(key);
+        return entry != null && entry.getStatus() == Key.KEY_JUST_DOWN
+                && entry.getMods() == mods;
+    }
+
+    /**
+     * Indicates whether a key is currently being pressed.
+     *
+     * @param key The key code (constant from {@link GLFW}) of the key to check.
+     *
+     * @return true if the key is being pressed.
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public boolean isKeyDown(int key)
+    {
+        return isKeyDown(key, 0);
+    }
+
+    /**
+     * Indicates whether a key + mods combination is currently being pressed.
+     *
+     * @param key  The key code (constant from {@link GLFW}) of the key to check.
+     * @param mods Bitmask of the mods that are pressed with the key, i.e shift and alt.
+     *
+     * @return true if the key is being pressed.
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public boolean isKeyDown(int key, int mods)
+    {
+        var entry = this.keyValues.get(key);
+        return entry != null
+                && (entry.getStatus() == Key.KEY_DOWN || entry.getStatus() == Key.KEY_JUST_DOWN)
+                && entry.getMods() == mods;
+    }
+
+    /**
+     * Indicates whether a key was recently pressed and is now released.
+     *
+     * @param key The key code (constant from {@link GLFW}) of the key to check.
+     *
+     * @return true if the key has been pressed somewhere in the past and was released during the last tick.
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public boolean isKeyReleased(int key)
+    {
+        return isKeyReleased(key, 0);
+    }
+
+    /**
+     * Indicates whether a key + mods combination was recently pressed and is now released.
+     *
+     * @param key  The key code (constant from {@link GLFW}) of the key to check.
+     * @param mods Bitmask of the mods that are pressed with the key, i.e shift and alt.
+     *
+     * @return true if the key has been pressed somewhere in the past and was released during the last tick.
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public boolean isKeyReleased(int key, int mods)
+    {
+        var entry = this.keyValues.get(key);
+        return entry != null
+                && entry.getStatus() == Key.KEY_RELEASED
+                && entry.getMods() == mods;
+    }
+
+    /**
+     * Callback for GLFW.
+     *
+     * @param window   The window reference.
+     * @param key      The keycode of the pressed key.
+     * @param scancode The system-specific scancode of the key
+     * @param action   The action of this event, i.e release.
+     * @param mods     The the modifications of this action, i.e. shift or alt.
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    protected void onKeyAction(long window, int key, int scancode, int action, int mods)
+    {
+        if (action == GLFW.GLFW_RELEASE)
+        {
+            keyReleased(key, mods);
+        }
+        else
+        {
+            keyPressed(key, mods);
+        }
+    }
+
+    /**
+     * Marks the given key + mods combination as pressed if it isnt already.
+     * <p>
+     * This is only a staged change, it will come into effect after the next {@link #checkKeyChanges()} call.
+     *
+     * @param key  the keycode
+     * @param mods the mods, i.e. shift ro alt
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    protected void keyPressed(int key, int mods)
+    {
+        synchronized (this.keyChanges)
+        {
+            if (!isKeyDown(key, mods))
+            {
+                this.keyChanges.put(key, new Key(key, Key.KEY_JUST_DOWN, mods));
+            }
+        }
+    }
+
+    /**
+     * Marks the given key + mods combination as released if it isnt already.
+     * <p>
+     * This is only a staged change, it will come into effect after the next {@link #checkKeyChanges()} call.
+     *
+     * @param key  the keycode
+     * @param mods the mods, i.e. shift ro alt
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    protected void keyReleased(int key, int mods)
+    {
+        synchronized (this.keyChanges)
+        {
+            this.keyChanges.put(key, new Key(key, Key.KEY_RELEASED, mods));
+        }
+    }
+
+    /**
+     * Checks for new staged key changes.
+     * <p>
+     * First this method will update the states of already known keys.
+     * It changes 'recently released' to 'not down' and 'just down' to 'down'.
+     * <p>
+     * After that the staged changes will be added to the main key map and are
+     * then available to calls like {@link #isKeyDown(int, int) isKeyDown}.
+     *
+     * @author Lukas Hartwig
+     * @since 03.11.2021
+     */
+    public void checkKeyChanges()
+    {
+        // changing 'recently released' to 'not down' and 'just down' to 'down'
+        this.keyValues.replaceAll((k, v) ->
+                                  {
+                                      if (v.getStatus() == Key.KEY_RELEASED)
+                                      {
+                                          v.setStatus(Key.KEY_NOT_DOWN);
+                                      }
+                                      else if (v.getStatus() == Key.KEY_JUST_DOWN)
+                                      {
+                                          v.setStatus(Key.KEY_DOWN);
+                                      }
+
+                                      return v;
+                                  });
+
+        // merge staged changes into main map and clear changes afterwards
+        synchronized (this.keyChanges)
+        {
+            for (var key : this.keyChanges.keySet())
+            {
+                this.keyValues.put(key, this.keyChanges.get(key));
+            }
+
+            this.keyChanges.clear();
+        }
+    }
+}

--- a/src/bt2d/core/input/key/KeyInput.java
+++ b/src/bt2d/core/input/key/KeyInput.java
@@ -15,10 +15,6 @@ import java.util.Map;
  */
 public class KeyInput
 {
-    /**
-     * The singleton instance.
-     */
-    private volatile static KeyInput instance;
 
     /**
      * The keys mapped by their keycode keeping track of their status.
@@ -40,23 +36,9 @@ public class KeyInput
      */
     public KeyInput(long windowRef)
     {
-        instance = this;
         this.keyValues = new HashMap<>();
         this.keyChanges = new HashMap<>();
         GLFW.glfwSetKeyCallback(windowRef, this::onKeyAction);
-    }
-
-    /**
-     * Get key input.
-     *
-     * @return the key input
-     *
-     * @author Lukas Hartwig
-     * @since 03.11.2021
-     */
-    public static KeyInput get()
-    {
-        return instance;
     }
 
     /**


### PR DESCRIPTION
Added a key listener which updates every tick and allows synchronized actions on the main thread by checking if certain keys or key + mods combinations (CTRL + A) are pressed or were just pressed.

The GameContainer sets up a KeyInput for the created window and exposes it via a public getter.

Additionally to KeyInput there is now a KeyActions class which allows the creation of a set of key to action mappings. This for one removes if clutter in tick methods and adds the option to have global key actions configured for the game container.

The game container will create an empty KeyActions instance and exposes it via a getter. This instance will be ticked automatically by the container.

A basic example would look like this:
(game being an instance of GameContainer)

```
// closes the game when pressing ESC
game.getKeyActions().onKeyDown(GLFW.GLFW_KEY_ESCAPE, game::kill);
```

```
// types 'A' in the console when pressing shift + a
game.getKeyActions().onKeyJustDown(GLFW.GLFW_KEY_A, GLFW.GLFW_MOD_SHIFT, () -> System.out.println("A"));
```

Closes #9 